### PR TITLE
Provide a Sequelize back end for node-login

### DIFF
--- a/app.js
+++ b/app.js
@@ -15,7 +15,7 @@ var cookieParser = require('cookie-parser');
 var app = express();
 
 // Set your database back end here (to "mongo", "memory", or "sequelize")
-app.set("node-login db backend", "sequelize");
+app.set("node-login db backend", "mongo");
 
 var store;
 if (app.settings["node-login db backend"] == "mongo") {

--- a/app/server/modules/account-manager-memory.js
+++ b/app/server/modules/account-manager-memory.js
@@ -1,0 +1,175 @@
+var moment 		= require('moment'),
+	crypto 		= require('crypto');
+
+/* A "memory" database, which just stores data in memory (and so does not persist). Useful
+   for testing, and as a base implementation of a database. */
+
+/* establish the database connection */
+
+var accounts = {};
+
+/* login validation methods */
+
+exports.autoLogin = function(user, pass, callback)
+{
+	var ac = accounts[user];
+	if (ac) {
+		if (ac.pass) {
+			callback(ac);
+		} else {
+			callback(null);
+		}
+	} else {
+		callback(null);
+	}
+};
+
+exports.manualLogin = function(user, pass, callback)
+{
+	var ac = accounts[user];
+	if (!ac) {
+		callback("user-not-found");
+	} else {
+		if (validatePassword(pass, ac.pass)) {
+			callback(null, ac);
+		} else {
+			callback("invalid-password");
+		}
+	}
+};
+
+/* record insertion, update & deletion methods */
+
+exports.addNewAccount = function(newData, callback)
+{
+	var ac = accounts[newData.user];
+	if (ac) {
+		callback("username-taken");
+	} else {
+		if (inefficientFindByEmail(newData.email)) {
+			callback("email-taken");
+			return;
+		}
+		saltAndHash(newData.pass, function(hash) {
+			newData.pass = hash;
+			// append date stamp when record was created //
+			newData.date = moment().format('MMMM Do YYYY, h:mm:ss a');
+			accounts[newData.user] = newData;
+			accounts[newData.user]._id = "id" + Math.round(Math.random() * 1000000);
+			callback(null, accounts[newData.user]);
+		});
+	}
+};
+
+exports.updateAccount = function(newData, callback)
+{
+	var ac = accounts[newData.user];
+	ac.name = newData.name;
+	ac.email = newData.email;
+	ac.country = newData.country;
+	if (newData.pass === "") {
+		callback(null, ac);
+	} else {
+		saltAndHash(newData.pass, function(hash) {
+			ac.pass = hash;
+			callback(null, ac);
+		});
+	}
+};
+
+exports.updatePassword = function(email, newPass, callback)
+{
+	var ac = inefficientFindByEmail(email);
+	if (!ac) {
+		callback(new Error("No such account"));
+	} else {
+		saltAndHash(newPass, function(hash) {
+			ac.pass = hash;
+			callback(null, ac);
+		});
+	}
+};
+
+/* account lookup methods */
+
+exports.deleteAccount = function(id, callback)
+{
+	var found;
+	for (var k in accounts) {
+		if (accounts[k]._id == id) {
+			found = k;
+		}
+	}
+	if (found) { delete accounts[found]; }
+	callback(null);
+};
+
+exports.getAccountByEmail = function(email, callback)
+{
+	callback(inefficientFindByEmail(email));
+};
+
+exports.validateResetLink = function(email, passHash, callback)
+{
+	var ac = inefficientFindByEmail(email);
+	if (ac && ac.pass == passHash) {
+		return "ok";
+	}
+};
+
+exports.getAllRecords = function(callback)
+{
+	var res = [], ac;
+	for (var k in accounts) {
+		ac = JSON.parse(JSON.stringify(accounts[k]));
+		ac.id = k;
+		res.push(ac);
+	}
+	callback(null, res);
+};
+
+exports.delAllRecords = function(callback)
+{
+	accounts = {};
+	callback(null);
+	// reset accounts collection for testing //
+};
+
+/* private encryption & validation methods */
+
+var inefficientFindByEmail = function(email) {
+	for (var k in accounts) {
+		if (accounts[k].email == newData.email) {
+			return accounts[k];
+		}
+	}
+};
+
+var generateSalt = function()
+{
+	var set = '0123456789abcdefghijklmnopqurstuvwxyzABCDEFGHIJKLMNOPQURSTUVWXYZ';
+	var salt = '';
+	for (var i = 0; i < 10; i++) {
+		var p = Math.floor(Math.random() * set.length);
+		salt += set[p];
+	}
+	return salt;
+};
+
+var md5 = function(str) {
+	return crypto.createHash('md5').update(str).digest('hex');
+};
+
+var saltAndHash = function(pass, callback)
+{
+	var salt = generateSalt();
+	callback(salt + md5(pass + salt));
+};
+
+var validatePassword = function(plainPass, hashedPass, callback)
+{
+	var salt = hashedPass.substr(0, 10);
+	var validHash = salt + md5(plainPass + salt);
+	return hashedPass === validHash;
+};
+

--- a/app/server/modules/account-manager-sequelize.js
+++ b/app/server/modules/account-manager-sequelize.js
@@ -1,0 +1,207 @@
+var moment 		= require('moment'),
+	crypto 		= require('crypto'),
+	Sequelize	= require('sequelize');
+
+/* A SQL database, connected to with Sequelize */
+
+/* establish the database connection */
+
+var sequelize = new Sequelize(process.env.DATABASE_URL);
+var accounts = sequelize.define('User', {
+	name: Sequelize.STRING,
+	email: Sequelize.STRING,
+	user: Sequelize.STRING,
+	pass: Sequelize.STRING,
+	country: Sequelize.STRING
+});
+sequelize.sync();
+
+/* login validation methods */
+
+exports.autoLogin = function(user, pass, callback)
+{
+	accounts.findOne({user:user}).then(function(o) {
+		if (o) {
+			if (o.pass == pass) {
+				o = o.get(); // make a dict, not a Sequelize instance
+				o._id = o.id;
+				callback(o);
+			} else {
+				callback(null);
+			}
+		} else{
+			callback(null);
+		}
+	}, callback);
+};
+
+exports.manualLogin = function(user, pass, callback)
+{
+	accounts.findOne({user:user}).then(function(o) {
+		if (o === null){
+			callback('user-not-found');
+		} else{
+			validatePassword(pass, o.pass, function(err, res) {
+				if (res) {
+					o = o.get(); // make a dict, not a Sequelize instance
+					o._id = o.id;
+					callback(null, o);
+				} else {
+					callback('invalid-password');
+				}
+			});
+		}
+	});
+};
+
+/* record insertion, update & deletion methods */
+
+exports.addNewAccount = function(newData, callback)
+{
+	accounts.findOne({user:newData.user}).then(function(o) {
+		if (o) {
+			callback('username-taken');
+		} else{
+			accounts.findOne({email:newData.email}).then(function(o) {
+				if (o) {
+					callback('email-taken');
+				}	else{
+					saltAndHash(newData.pass, function(hash){
+						newData.pass = hash;
+						// Sequelize automatically adds createdAt column
+						accounts.create(newData).then(function() {
+							callback();
+						}, function(err) {
+							callback(err);
+						});
+					});
+				}
+			});
+		}
+	});
+};
+
+exports.updateAccount = function(newData, callback)
+{
+	accounts.findOne({user:newData.user}).then(function(o) {
+		o.name 		= newData.name;
+		o.email 	= newData.email;
+		o.country 	= newData.country;
+		if (newData.pass === '') {
+			o.save().then(function() {
+				o = o.get(); // make a dict, not a Sequelize instance
+				o._id = o.id;
+				callback(null, o);
+			}, function(err) { callback(err); });
+		}	else{
+			saltAndHash(newData.pass, function(hash){
+				o.pass = hash;
+				o.save().then(function() {
+					o = o.get(); // make a dict, not a Sequelize instance
+					o._id = o.id;
+					callback(null, o);
+				}, function(err) { callback(err); });
+			});
+		}
+	});
+};
+
+exports.updatePassword = function(email, newPass, callback)
+{
+	accounts.findOne({email:email}).then(function(o) {
+		saltAndHash(newPass, function(hash) {
+			o.pass = hash;
+			o.save().then(function() {
+				o = o.get(); // make a dict, not a Sequelize instance
+				o._id = o.id;
+				callback(null, o);
+			}, function(err) { callback(err); });
+		});
+	}, function(err) { callback(err); });
+};
+
+/* account lookup methods */
+
+exports.deleteAccount = function(id, callback)
+{
+	accounts.destroy({where: {id: id}}).then(callback);
+};
+
+exports.getAccountByEmail = function(email, callback)
+{
+	accounts.findOne({email:email}).then(callback);
+};
+
+exports.validateResetLink = function(email, passHash, callback)
+{
+	accounts.find({ where: { $and: [{email:email, pass:passHash}] } }).then(function(o){
+		callback(o ? 'ok' : null);
+	});
+};
+
+exports.getAllRecords = function(callback)
+{
+	accounts.findAll().then(function(results) { callback(null, results); }, callback);
+};
+
+exports.delAllRecords = function(callback)
+{
+	accounts.destroy({truncate:true}).then(callback); // reset accounts collection for testing //
+};
+
+/* private encryption & validation methods */
+
+var generateSalt = function()
+{
+	var set = '0123456789abcdefghijklmnopqurstuvwxyzABCDEFGHIJKLMNOPQURSTUVWXYZ';
+	var salt = '';
+	for (var i = 0; i < 10; i++) {
+		var p = Math.floor(Math.random() * set.length);
+		salt += set[p];
+	}
+	return salt;
+};
+
+var md5 = function(str) {
+	return crypto.createHash('md5').update(str).digest('hex');
+};
+
+var saltAndHash = function(pass, callback)
+{
+	var salt = generateSalt();
+	callback(salt + md5(pass + salt));
+};
+
+var validatePassword = function(plainPass, hashedPass, callback)
+{
+	var salt = hashedPass.substr(0, 10);
+	var validHash = salt + md5(plainPass + salt);
+	callback(null, hashedPass === validHash);
+};
+
+/* auxiliary methods */
+
+var getObjectId = function(id)
+{
+	return new require('mongodb').ObjectID(id);
+};
+
+var findById = function(id, callback)
+{
+	accounts.findOne({_id: getObjectId(id)},
+		function(e, res) {
+		if (e) { callback(e); }
+		else { callback(null, res); }
+	});
+};
+
+
+var findByMultipleFields = function(a, callback)
+{
+// this takes an array of name/val pairs to search against {fieldName : 'value'} //
+	accounts.find( { $or : a } ).toArray(
+		function(e, results) {
+		if (e) { callback(e); }
+		else { callback(null, results); }
+	});
+};

--- a/app/server/routes.js
+++ b/app/server/routes.js
@@ -1,9 +1,20 @@
 
 var CT = require('./modules/country-list');
-var AM = require('./modules/account-manager');
 var EM = require('./modules/email-dispatcher');
 
 module.exports = function(app) {
+
+	var AM;
+	if (app.settings["node-login db backend"] === "mongo") {
+		AM = require('./modules/account-manager');
+	} else if (app.settings["node-login db backend"] === "sequelize") {
+		AM = require('./modules/account-manager-sequelize');
+	} else if (app.settings["node-login db backend"] === "memory") {
+		AM = require('./modules/account-manager-memory');
+	} else {
+		throw new Error("Unknown db backend '" + app.settings["node-login db backend"] + "'");
+	}
+
 
 // main login page //
 
@@ -29,6 +40,7 @@ module.exports = function(app) {
 			if (!o){
 				res.status(400).send(e);
 			}	else{
+				console.log("POSTED, got user", o);
 				req.session.user = o;
 				if (req.body['remember-me'] == 'true'){
 					res.cookie('user', o.user, { maxAge: 900000 });
@@ -46,6 +58,7 @@ module.exports = function(app) {
 	// if user is not logged-in redirect back to login page //
 			res.redirect('/');
 		}	else{
+			console.log("user is", req.session.user);
 			res.render('home', {
 				title : 'Control Panel',
 				countries : CT,

--- a/app/server/routes.js
+++ b/app/server/routes.js
@@ -40,7 +40,6 @@ module.exports = function(app) {
 			if (!o){
 				res.status(400).send(e);
 			}	else{
-				console.log("POSTED, got user", o);
 				req.session.user = o;
 				if (req.body['remember-me'] == 'true'){
 					res.cookie('user', o.user, { maxAge: 900000 });
@@ -58,7 +57,6 @@ module.exports = function(app) {
 	// if user is not logged-in redirect back to login page //
 			res.redirect('/');
 		}	else{
-			console.log("user is", req.session.user);
 			res.render('home', {
 				title : 'Control Panel',
 				countries : CT,


### PR DESCRIPTION
Added a separate Sequelize back end so that node-login can be used with a SQL DB instead of Mongo if one chooses.