### PR TITLE
Fix syntax of readme.md markdown.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,8 @@
-#[Node-Login](https://nodejs-login.herokuapp.com)
+# [Node-Login](https://nodejs-login.herokuapp.com)
 
 [![node-login](./readme.img/node-login.jpg?raw=true)](https://nodejs-login.herokuapp.com)
 
-###A basic account management system built in Node.js with the following features:
+### A basic account management system built in Node.js with the following features:
 
 * New User Account Creation
 * Secure Password Reset via Email
@@ -12,7 +12,7 @@
 * Blowfish-based Scheme Password Encryption
 
 
-###Node-Login is built on top of the following libraries :
+### Node-Login is built on top of the following libraries :
 
 * [Node.js](http://nodejs.org/) - Application Server
 * [Express.js](http://expressjs.com/) - Node.js Web Framework
@@ -24,7 +24,7 @@
 * [Twitter Bootstrap](http://twitter.github.com/bootstrap/) - UI Component & Layout Library
 
 
-##Installation & Setup
+## Installation & Setup
 1. Install [Node.js](https://nodejs.org/) & [MongoDB](https://www.mongodb.org/) if you haven't already.
 2. Clone this repository and install its dependencies.
 		
@@ -42,7 +42,7 @@
 		
 5. Open a browser window and navigate to: [http://localhost:3000](http://localhost:3000)
 
-##Password Retrieval
+## Password Retrieval
 
 To enable the password retrieval feature it is recommended that you create environment variables for your credentials instead of hard coding them into the [email dispatcher module](https://github.com/braitsch/node-login/blob/master/app/server/modules/email-dispatcher.js).
 
@@ -54,13 +54,13 @@ To do this on OSX you can simply add them to your .profile or .bashrc file.
 
 [![node-login](./readme.img/retrieve-password.jpg?raw=true)](https://nodejs-login.herokuapp.com)
 
-##Live Demo
+## Live Demo
 
 A [Live Demo](https://nodejs-login.herokuapp.com) and [some thoughts about the app's architecture.](http://kitchen.braitsch.io/building-a-login-system-in-node-js-and-mongodb/)
 
 For testing purposes you can view a [database dump of all accounts here](https://nodejs-login.herokuapp.com/print).    
 Note this database automatically resets every 24 hours.
 
-##Contributing
+## Contributing
 
 Questions and suggestions for improvement are welcome.


### PR DESCRIPTION
GitHub's markdown parser requires space after #s in title lines.